### PR TITLE
Explicitly mention config as a setup step

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Installation instructions (dev)
 
 * Create a new Python 3.6+ virtualenv and activate it
 * Run `pip install -e .`
+* Create a configuration YAML file and set the `MINIHAI_CONFIG` envvar (see Configuration)
 * Run `minihai start`
 * Point your Jupyhai-enabled Jupyter Notebook to use Minihai for execution:  
   `env VALOHAI_HOST=http://127.0.0.1:8000/ jupyter notebook`


### PR DESCRIPTION
This is due to `minihai start` failing without a config as it tries to set `os.environ["MINIHAI_CONFIG"] = None`.

Just a suggestion 🤷‍♀️ 